### PR TITLE
Add installation guide and scripts for GiraffeCloud CLI

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,118 @@
+## Installation
+
+This guide shows how to install the GiraffeCloud CLI on macOS, Linux, and Windows with a single line.
+
+### Quick install
+
+macOS/Linux (Bash):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.ps1 | iex
+```
+
+After installation, you can verify:
+
+```bash
+giraffecloud version
+```
+
+### Optional parameters
+
+macOS/Linux script (`install.sh`):
+
+- **--system**: Install system-wide to `/usr/local/bin` (requires sudo). Default: user install to `~/.local/bin`.
+- **--service [user|system]**: Install and start the service using systemd (Linux only). Default: none.
+- **--url <tar.gz>**: Install from a specific release asset URL instead of auto-detecting the latest.
+- **--token <API_TOKEN>**: Run `giraffecloud login --token <API_TOKEN>` after install.
+
+Example:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.sh | bash -s -- --service user --token YOUR_API_TOKEN
+```
+
+Windows script (`install.ps1`):
+
+- **-System**: Install system-wide to `C:\\Program Files\\GiraffeCloud\\bin` (requires elevated PowerShell). Default: user install to `%LOCALAPPDATA%\giraffecloud\bin`.
+- **-Url <zip|tar.gz>**: Install from a specific release asset URL instead of auto-detecting the latest.
+- **-Token <API_TOKEN>**: Run `giraffecloud login --token <API_TOKEN>` after install.
+
+Example:
+
+```powershell
+iex "& { $(iwr -useb https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.ps1) } -System -Token 'YOUR_API_TOKEN'"
+```
+
+### PATH updates and shell refresh
+
+- macOS/Linux user install goes to `~/.local/bin`. If it is not on your `PATH`, the installer will add it to your shell rc (`~/.zshrc` or `~/.bashrc`) and prompt you to `source` it or open a new terminal.
+- System installs go to `/usr/local/bin`, which is typically already on `PATH`.
+- Windows installer adds the chosen install directory to the User or Machine `PATH` and broadcasts the change so new terminals pick it up. You may need to open a new terminal.
+
+### Service installation (Linux only)
+
+When `--service user|system` is provided on Linux, the installer invokes `giraffecloud service install` and will attempt to restart the systemd unit (`giraffecloud`). This is skipped on macOS and Windows.
+
+### Install from a specific release
+
+- macOS/Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.sh | bash -s -- --url https://github.com/osa911/giraffecloud/releases/download/vX.Y.Z/giraffecloud_linux_amd64_vX.Y.Z.tar.gz
+```
+
+- Windows (PowerShell):
+
+```powershell
+iex "& { $(iwr -useb https://raw.githubusercontent.com/osa911/giraffecloud/main/scripts/install.ps1) } -Url 'https://github.com/osa911/giraffecloud/releases/download/vX.Y.Z/giraffecloud_windows_amd64_vX.Y.Z.zip'"
+```
+
+Asset naming convention (examples):
+
+- `giraffecloud_linux_amd64_vX.Y.Z.tar.gz`
+- `giraffecloud_darwin_arm64_vX.Y.Z.tar.gz`
+- `giraffecloud_windows_amd64_vX.Y.Z.zip`
+
+### Uninstall
+
+macOS/Linux (user install):
+
+```bash
+rm -f ~/.local/bin/giraffecloud
+# Optionally remove the PATH line from ~/.zshrc or ~/.bashrc if you added it manually
+```
+
+macOS/Linux (system install):
+
+```bash
+sudo rm -f /usr/local/bin/giraffecloud
+```
+
+Windows:
+
+```powershell
+Remove-Item -LiteralPath "$env:LOCALAPPDATA\giraffecloud\bin\giraffecloud.exe" -ErrorAction SilentlyContinue
+# Or, if installed system-wide:
+# Remove-Item -LiteralPath 'C:\\Program Files\\GiraffeCloud\\bin\\giraffecloud.exe' -ErrorAction SilentlyContinue
+```
+
+### Troubleshooting
+
+- "command not found" after install:
+  - Open a new terminal to pick up `PATH` changes
+  - Ensure `~/.local/bin` (Linux/macOS user install) is in your `PATH`
+  - On Windows, verify the install directory exists and is in `PATH`
+- Service install skipped on macOS:
+  - This is expected. Service installation is supported on Linux (systemd) only.
+- Corporate proxy / SSL interception:
+  - Download the release archive manually and pass `--url` (Linux/macOS) or `-Url` (Windows) to the installer.
+
+### Security note
+
+The one-liner uses `curl | bash` (or PowerShell `iwr | iex`). Review the script before running by opening its URL in a browser.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,173 @@
+# GiraffeCloud Windows PowerShell installer
+# - Installs the giraffecloud CLI for the current user (default) or system-wide (-System)
+# - Optionally logs in with a provided token (-Token <API_TOKEN>)
+# - If -Url is omitted, fetches the latest release asset for Windows/ARCH from GitHub API
+
+[CmdletBinding(PositionalBinding=$false)]
+param(
+  [string]$Url,
+  [string]$Token,
+  [switch]$System
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Owner = 'osa911'
+$Repo  = 'giraffecloud'
+
+function Write-Info($msg) { Write-Host $msg -ForegroundColor Cyan }
+function Write-Err($msg)  { Write-Host $msg -ForegroundColor Red }
+function Is-Admin {
+  $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($currentIdentity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
+function Ensure-Tls12 {
+  try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+  } catch { }
+}
+
+function Get-Arch {
+  switch -Regex ($env:PROCESSOR_ARCHITECTURE) {
+    'ARM64' { 'arm64'; break }
+    'AMD64' { 'amd64'; break }
+    default { throw "Unsupported architecture: $($env:PROCESSOR_ARCHITECTURE)" }
+  }
+}
+
+function Resolve-LatestUrl {
+  param([string]$arch)
+  Ensure-Tls12
+  $api = "https://api.github.com/repos/$Owner/$Repo/releases/latest"
+  $release = Invoke-RestMethod -UseBasicParsing -Uri $api
+  # Prefer .zip assets for Windows
+  $asset = $release.assets |
+    Where-Object { $_.browser_download_url -match "giraffecloud_windows_${arch}_.*\.zip$" } |
+    Select-Object -First 1
+  if (-not $asset) {
+    # Fallback: try .tar.gz (in case assets are not zipped for Windows)
+    $asset = $release.assets |
+      Where-Object { $_.browser_download_url -match "giraffecloud_windows_${arch}_.*\.tar\.gz$" } |
+      Select-Object -First 1
+  }
+  if (-not $asset) { throw "Could not find a matching Windows $arch asset in latest release." }
+  return $asset.browser_download_url
+}
+
+function Add-ToPathIfMissing {
+  param([string]$dir, [ValidateSet('User','Machine')] [string]$scope)
+
+  $sep = ';'
+  $currentUserPath   = [Environment]::GetEnvironmentVariable('Path','User')
+  $currentMachinePath= [Environment]::GetEnvironmentVariable('Path','Machine')
+  $pathForScope = if ($scope -eq 'Machine') { $currentMachinePath } else { $currentUserPath }
+
+  $hasDir = ($pathForScope -split ';') | Where-Object { $_ -ieq $dir } | ForEach-Object { $true } | Select-Object -First 1
+  if (-not $hasDir) {
+    $newPath = if ([string]::IsNullOrEmpty($pathForScope)) { $dir } else { "$pathForScope$sep$dir" }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, $scope)
+  }
+
+  # Ensure current session picks it up immediately
+  if (-not (($env:Path -split ';') -contains $dir)) {
+    $env:Path = "$dir;$env:Path"
+  }
+
+  try {
+    # Broadcast change so new processes pick up updated PATH
+    $signature = @'
+using System;
+using System.Runtime.InteropServices;
+public class EnvBroadcaster {
+  [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+  public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, int fuFlags, int uTimeout, out IntPtr lpdwResult);
+}
+'@
+    Add-Type -TypeDefinition $signature -ErrorAction SilentlyContinue | Out-Null
+    $HWND_BROADCAST = [IntPtr]0xffff
+    $WM_SETTINGCHANGE = 0x1A
+    [IntPtr]$result = [IntPtr]::Zero
+    [void][EnvBroadcaster]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [IntPtr]::Zero, 'Environment', 0x0002, 5000, [ref]$result)
+  } catch { }
+}
+
+try {
+  $arch = Get-Arch
+
+  if ([string]::IsNullOrWhiteSpace($Url)) {
+    Write-Info "Resolving latest release for windows/$arch..."
+    $Url = Resolve-LatestUrl -arch $arch
+  }
+
+  $tmp = Join-Path $env:TEMP ("giraffecloud_" + [Guid]::NewGuid().ToString('N'))
+  New-Item -ItemType Directory -Path $tmp | Out-Null
+  $cleanup = {
+    try { Remove-Item -Recurse -Force -LiteralPath $tmp -ErrorAction SilentlyContinue } catch {}
+  }
+  Register-EngineEvent PowerShell.Exiting -Action $cleanup | Out-Null
+
+  $fileName = if ($Url -match '\.zip$') { 'giraffecloud.zip' } elseif ($Url -match '\.tar\.gz$') { 'giraffecloud.tar.gz' } else { 'giraffecloud.bin' }
+  $archivePath = Join-Path $tmp $fileName
+
+  Write-Info "Downloading: $Url"
+  Ensure-Tls12
+  Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $archivePath
+
+  Write-Info 'Extracting...'
+  if ($archivePath -like '*.zip') {
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $tmp -Force
+  } elseif ($archivePath -like '*.tar.gz') {
+    # Try tar if available (Windows 10+ ships bsdtar under tar.exe)
+    & tar -xzf $archivePath -C $tmp
+  } else {
+    throw 'Unknown archive format. Expected .zip or .tar.gz'
+  }
+
+  Write-Info 'Locating binary...'
+  $exe = Get-ChildItem -Path $tmp -Recurse -Filter 'giraffecloud.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $exe) { throw 'giraffecloud.exe not found in archive' }
+
+  $isAdmin = Is-Admin
+  if ($System) {
+    if (-not $isAdmin) {
+      Write-Err 'System-wide install requested but PowerShell is not elevated. Falling back to user install.'
+      $System = $false
+    }
+  }
+
+  if ($System) {
+    $destDir = 'C:\\Program Files\\GiraffeCloud\\bin'
+  } else {
+    $destDir = Join-Path $env:LOCALAPPDATA 'giraffecloud\\bin'
+  }
+
+  New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+  $dest = Join-Path $destDir 'giraffecloud.exe'
+  Copy-Item -LiteralPath $exe.FullName -Destination $dest -Force
+
+  $scope = if ($System) { 'Machine' } else { 'User' }
+  Add-ToPathIfMissing -dir $destDir -scope $scope
+
+  Write-Host "Installed: $dest" -ForegroundColor Green
+
+  if ($Token) {
+    Write-Info 'Logging in...'
+    & $dest login --token $Token
+  }
+
+  Write-Host ''
+  Write-Host 'Success. You can now run:'
+  Write-Host '  giraffecloud.exe version'
+  Write-Host '  giraffecloud.exe config path'
+  Write-Host '  giraffecloud.exe connect'
+  Write-Host ''
+  Write-Host 'If the command is not found, open a new terminal window to pick up PATH changes.'
+
+} catch {
+  Write-Err $_.Exception.Message
+  exit 1
+}
+
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GiraffeCloud installer
+# - Installs the giraffecloud CLI for the current user (default) or system-wide (--system)
+# - Optionally installs and starts the service (--service user|system)
+# - Optionally logs in with a provided token (--token <API_TOKEN>)
+# - If --url is omitted, tries to fetch latest release asset for the detected OS/ARCH from GitHub API
+
+REPO_OWNER="osa911"
+REPO_NAME="giraffecloud"
+
+INSTALL_MODE="user"          # user | system
+SERVICE_MODE="none"          # none | user | system
+RELEASE_URL=""
+LOGIN_TOKEN=""
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --system                 Install system-wide to /usr/local/bin (requires sudo). Default: user (~/.local/bin)
+  --service [user|system]  Install and start the service (user-level or system-level). Default: none
+  --url <tar.gz>           Release asset URL to install (skips GitHub API lookup)
+  --token <API_TOKEN>      Perform 'giraffecloud login --token <API_TOKEN>' after install
+  -h, --help               Show this help
+
+Examples:
+  $0 --service user
+  $0 --url https://github.com/osa911/giraffecloud/releases/download/test-XXXX/giraffecloud_linux_amd64_v0.0.0-test.XXXX.tar.gz
+  $0 --system --service system --token YOUR_API_TOKEN
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --system)
+      INSTALL_MODE="system"; shift ;;
+    --service)
+      SERVICE_MODE="${2:-user}"; shift 2 ;;
+    --url)
+      RELEASE_URL="${2:-}"; shift 2 ;;
+    --token)
+      LOGIN_TOKEN="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Error: required command '$1' not found" >&2; exit 1; }
+}
+
+require_cmd curl
+require_cmd tar
+
+# Detect OS/ARCH
+GOOS=$(uname | tr '[:upper:]' '[:lower:]')
+case "$GOOS" in
+  linux) OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *) echo "Unsupported OS: $GOOS" >&2; exit 1 ;;
+esac
+
+GOARCH=$(uname -m)
+case "$GOARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $GOARCH" >&2; exit 1 ;;
+esac
+
+TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t giraffecloud)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+resolve_latest_url() {
+  # Try to fetch latest release asset matching current OS/ARCH
+  local api="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
+  # We avoid jq; use grep/sed to extract a matching tar.gz url
+  local url
+  url=$(curl -fsSL "$api" \
+    | grep -Eo '"browser_download_url"\s*:\s*"[^"]+"' \
+    | sed -E 's/"browser_download_url"\s*:\s*"(.*)"/\1/' \
+    | grep "giraffecloud_${OS}_${ARCH}_.*\\.tar\\.gz" \
+    | head -n1 || true)
+  echo "$url"
+}
+
+if [[ -z "$RELEASE_URL" ]]; then
+  echo "Resolving latest release for ${OS}/${ARCH}..."
+  RELEASE_URL="$(resolve_latest_url)"
+  if [[ -z "$RELEASE_URL" ]]; then
+    echo "Failed to resolve latest release asset automatically. Provide --url <tar.gz>." >&2
+    exit 1
+  fi
+fi
+
+echo "Downloading: $RELEASE_URL"
+curl -fL -o "$TMPDIR/giraffecloud.tar.gz" "$RELEASE_URL"
+
+echo "Extracting..."
+tar -xzf "$TMPDIR/giraffecloud.tar.gz" -C "$TMPDIR"
+
+echo "Locating binary..."
+BIN_PATH="$(find "$TMPDIR" -type f -name giraffecloud -perm -u+x | head -n1 || true)"
+if [[ -z "$BIN_PATH" ]]; then
+  echo "Error: giraffecloud binary not found in archive" >&2
+  exit 1
+fi
+
+if [[ "$INSTALL_MODE" == "system" ]]; then
+  echo "Installing system-wide to /usr/local/bin (requires sudo)..."
+  sudo install -m 0755 "$BIN_PATH" /usr/local/bin/giraffecloud
+  DEST="/usr/local/bin/giraffecloud"
+else
+  echo "Installing to user bin (~/.local/bin)..."
+  mkdir -p "$HOME/.local/bin"
+  install -m 0755 "$BIN_PATH" "$HOME/.local/bin/giraffecloud"
+  DEST="$HOME/.local/bin/giraffecloud"
+  # Ensure PATH at runtime
+  case "${SHELL##*/}" in
+    bash)
+      if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+      fi ;;
+    zsh)
+      if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.zshrc" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
+      fi ;;
+  esac
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "Installed: $DEST"
+"$DEST" version || true
+
+# Optional login
+if [[ -n "$LOGIN_TOKEN" ]]; then
+  echo "Logging in..."
+  "$DEST" login --token "$LOGIN_TOKEN"
+fi
+
+# Track whether we added PATH to a shell rc file
+ADDED_PATH_TO_RC=0
+
+# Determine if destination directory is already in PATH of the caller's environment
+case "$DEST" in
+  /usr/local/bin/*)
+    DEST_DIR="/usr/local/bin" ;;
+  $HOME/.local/bin/*)
+    DEST_DIR="$HOME/.local/bin" ;;
+  *)
+    DEST_DIR="$(dirname "$DEST")" ;;
+esac
+
+PATH_HAS_DEST=0
+echo "$PATH" | tr ':' '\n' | grep -Fxq "$DEST_DIR" && PATH_HAS_DEST=1 || true
+
+# If user-mode install and PATH doesn't include ~/.local/bin, append to shell rc
+if [[ "$INSTALL_MODE" != "system" && $PATH_HAS_DEST -eq 0 ]]; then
+  case "${SHELL##*/}" in
+    bash)
+      if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+        ADDED_PATH_TO_RC=1
+      fi ;;
+    zsh)
+      if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.zshrc" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
+        ADDED_PATH_TO_RC=1
+      fi ;;
+  esac
+fi
+
+# Optional service install (Linux only for now)
+if [[ "$SERVICE_MODE" != "none" ]]; then
+  if [[ "$OS" != "linux" ]]; then
+    echo "Service installation is currently supported on Linux only; skipping." >&2
+  else
+    echo "Installing service: $SERVICE_MODE"
+    if [[ "$SERVICE_MODE" == "user" ]]; then
+      "$DEST" service install --user
+      command -v systemctl >/dev/null 2>&1 && systemctl --user restart giraffecloud || true
+    elif [[ "$SERVICE_MODE" == "system" ]]; then
+      sudo "$DEST" service install
+      command -v systemctl >/dev/null 2>&1 && sudo systemctl restart giraffecloud || true
+    else
+      echo "Unknown service mode: $SERVICE_MODE" >&2
+      exit 1
+    fi
+  fi
+fi
+
+echo
+if [[ $PATH_HAS_DEST -eq 1 ]]; then
+  echo "Success: Installed to $DEST and it's already on your PATH."
+  echo "Try: giraffecloud version"
+else
+  echo "Success: Installed to $DEST."
+  echo "It looks like $DEST_DIR is not on your PATH in this shell."
+  if [[ "$INSTALL_MODE" == "system" ]]; then
+    echo "Add /usr/local/bin to your PATH or open a new terminal."
+  else
+    case "${SHELL##*/}" in
+      zsh)
+        if [[ $ADDED_PATH_TO_RC -eq 1 ]]; then
+          echo "We've added ~/.local/bin to your ~/.zshrc. Run: source ~/.zshrc, or open a new terminal."
+        else
+          echo "Add this to your ~/.zshrc then run 'source ~/.zshrc':"
+          echo "  export PATH=\"$HOME/.local/bin:$PATH\""
+        fi ;;
+      bash)
+        if [[ $ADDED_PATH_TO_RC -eq 1 ]]; then
+          echo "We've added ~/.local/bin to your ~/.bashrc. Run: source ~/.bashrc, or open a new terminal."
+        else
+          echo "Add this to your ~/.bashrc then run 'source ~/.bashrc':"
+          echo "  export PATH=\"$HOME/.local/bin:$PATH\""
+        fi ;;
+      *)
+        echo "Add $HOME/.local/bin to your PATH and restart your shell:"
+        echo "  export PATH=\"$HOME/.local/bin:$PATH\"" ;;
+    esac
+  fi
+fi
+
+echo
+echo "Next steps:"
+echo "  giraffecloud config path"
+echo "  giraffecloud connect"
+
+


### PR DESCRIPTION
- Introduced `installation.md` to provide detailed installation instructions for macOS, Linux, and Windows.
- Added `install.sh` script for Unix-based systems, supporting user and system-wide installations, service management, and optional login.
- Created `install.ps1` script for Windows, enabling similar functionalities with PowerShell, including service installation and environment variable updates.
- Included troubleshooting tips and security notes regarding the installation process.